### PR TITLE
VGPU shader converter tweaks

### DIFF
--- a/src/gl/pack/shaderconv.c
+++ b/src/gl/pack/shaderconv.c
@@ -90,8 +90,8 @@ void shader_conv_(char **glshader_source, char **glshader_converted){//				Print
 	pot = replace("textureGather", "textureGather_", glshader_converted);	//Printf("Calling %d ", __LINE__);
 	replace_func_name("Offset", "Offset_", glshader_converted, FUNCTION_NAME);	//Printf("Calling %d ", __LINE__);
 	
-	replace_func_name("texture", "texture__", glshader_converted, VARIABLE_NAME);	//Printf("Calling %d ", __LINE__);						// Prevent conflict between variable name and function name.
-	replace_func_name("sample", "sample__", glshader_converted, VARIABLE_NAME);	//Printf("Calling %d ", __LINE__);						// Prevent conflict between variable name and function name.
+	replace_func_name("texture", "texture_t", glshader_converted, VARIABLE_NAME);	//Printf("Calling %d ", __LINE__);						// Prevent conflict between variable name and function name.
+	replace_func_name("sample", "sample_t", glshader_converted, VARIABLE_NAME);	//Printf("Calling %d ", __LINE__);						// Prevent conflict between variable name and function name.
 	//}
 	
 	int cut_in_offset;

--- a/src/gl/pack/shaderconv.c
+++ b/src/gl/pack/shaderconv.c
@@ -92,6 +92,7 @@ void shader_conv_(char **glshader_source, char **glshader_converted){//				Print
 	
 	replace_func_name("texture", "texture_t", glshader_converted, VARIABLE_NAME);	//Printf("Calling %d ", __LINE__);						// Prevent conflict between variable name and function name.
 	replace_func_name("sample", "sample_t", glshader_converted, VARIABLE_NAME);	//Printf("Calling %d ", __LINE__);						// Prevent conflict between variable name and function name.
+        replace_func_name("distance", "distance_t", glshader_converted, VARIABLE_NAME); 
 	//}
 	
 	int cut_in_offset;


### PR DESCRIPTION
This thing should fix errors like
`ERROR: 0:32: 'texture__' : identifiers cannot contain two consecutive underscores`
`ERROR: 0:32: 'distance' : redeclaring name`
on the output shader.